### PR TITLE
Add a few more SwiftLint snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ If you have any other Snippets that you would like to share make a Pull Request!
 - `swift_static_date_formatter`: Static date formatter snippet
 - `swift_tableview_data_source`: Bare bones required `UITableViewDataSource` methods
 - `swift_collectionview_data_source`: Bare bones required `UICollectionViewDataSource` methods
-- `swift_swiftlint_disable_enable`: Disable/enable a [SwiftLint](https://github.com/realm/SwiftLint) rule.
+- `swift_swiftlint_disable_enable`: Disable/enable a [SwiftLint](https://github.com/realm/SwiftLint) rule for a block of code.
+- `swift_swiftlint_disable_this`: Disable a [SwiftLint](https://github.com/realm/SwiftLint) rule for the current line of code.
+- `swift_swiftlint_disable_next`: Disable a [SwiftLint](https://github.com/realm/SwiftLint) rule for the next line of code.
+- `swift_swiftlint_disable_previous`: Disable a [SwiftLint](https://github.com/realm/SwiftLint) rule for the previous line of code.
 - `swift_source_code_tag`: Add a tag to link to source code via the `x-source-tag` URL scheme.
 - `swift_source_code_link`: Create a link to source code via the `x-source-tag` URL scheme.
 

--- a/swift_swiftlint_disable_next.codesnippet
+++ b/swift_swiftlint_disable_next.codesnippet
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>swiftlint_disable_next</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>// swiftlint:disable:next &lt;#Rule Name#&gt;</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>A43AEE5A-643A-4A99-A9DF-1E12501F2DEC</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>Disable a SwiftLint rule for the next line of code.</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>SwiftLint Disable Next</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/swift_swiftlint_disable_previous.codesnippet
+++ b/swift_swiftlint_disable_previous.codesnippet
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>swiftlint_disable_previous</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>// swiftlint:disable:previous &lt;#Rule Name#&gt;</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>C4F44081-867D-4BF3-95F0-DCCB68918849</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>Disable a SwiftLint rule for the previous line of code.</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>SwiftLint Disable Previous</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/swift_swiftlint_disable_this.codesnippet
+++ b/swift_swiftlint_disable_this.codesnippet
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>swiftlint_disable_this</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>// swiftlint:disable:this &lt;#Rule Name#&gt;</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>95444FA8-48B8-4A2C-B2C1-2882D9C253F7</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>Disable a SwiftLint rule for the current line of code.</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>SwiftLint Disable This</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>


### PR DESCRIPTION
This pr is for adding a few more hard-to-remember snippets for [disabling SwiftLint rules](https://github.com/realm/SwiftLint#disable-rules-in-code). This adds 3 snippets for:
- `// swiftlint:disable:this`
- `// swiftlint:disable:next`
- `// swiftlint:disable:previous`

@vokal/ios-developers review please

